### PR TITLE
Add verbose logging for snippet parsing and plugin build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+src/wpcode_tool.egg-info/
+*.egg-info
+build/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
-# wpcode
-wpcode to app
+# WPCode Export to Plugin Tool
+
+This project provides utilities to convert a [WPCode](https://wpcode.com/) export into a standalone WordPress plugin. Active snippets from the export are normalized, mapped to sensible hook locations, and written into an installable plugin complete with an admin interface for manual review.
+
+## Features
+
+- Parses WPCode export files and keeps only the active snippets.
+- Maps each snippet to a WordPress hook when the location is known, or flags it for manual placement.
+- Generates a full plugin directory including snippet files, loader logic, and a polished admin page that highlights snippets needing review.
+- Command line interface for building plugins from exports.
+- Automated tests covering the parser and plugin builder.
+
+## Usage
+
+1. Install the project in editable mode (optional):
+
+   ```bash
+   pip install -e .
+   ```
+
+2. Generate a plugin from an export:
+
+   ```bash
+   wpcode-tool path/to/export.json --output build/ --slug my-generated-plugin --name "My Generated Plugin"
+   ```
+
+   The command creates a plugin directory at `build/my-generated-plugin/`.
+
+   Add `--verbose` to see a step-by-step breakdown of which snippets are detected and which files are written:
+
+   ```bash
+   wpcode-tool path/to/export.json --output build/ --slug my-generated-plugin --name "My Generated Plugin" --verbose
+   ```
+
+3. Zip or copy the generated folder into a WordPress installation's `wp-content/plugins/` directory and activate it from the admin dashboard.
+
+## Tests
+
+Run the automated test suite with:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wpcode-tool"
+version = "0.1.0"
+description = "Utility to convert WPCode exports into WordPress plugins"
+authors = [{name = "AI Assistant"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
+
+[project.scripts]
+wpcode-tool = "wpcode_tool.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/wpcode_tool/__init__.py
+++ b/src/wpcode_tool/__init__.py
@@ -1,0 +1,6 @@
+"""WPCode export conversion utilities."""
+
+from .builder import build_plugin
+from .parser import load_snippets
+
+__all__ = ["build_plugin", "load_snippets"]

--- a/src/wpcode_tool/builder.py
+++ b/src/wpcode_tool/builder.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import shutil
+import textwrap
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from .mapper import plan_snippet
+from .models import PlannedSnippet, Snippet
+
+
+def _resolve_logger(verbose: bool, log):
+    if verbose:
+        return log or print
+    return None
+
+
+def _sanitize_slug(value: str) -> str:
+    sanitized = "".join(ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in value.lower())
+    sanitized = "-".join(filter(None, sanitized.split("-")))
+    return sanitized or "snippet"
+
+
+def _unique_slug(base: str, existing: Dict[str, int]) -> str:
+    count = existing.get(base, 0)
+    if count == 0 and base not in existing:
+        existing[base] = 1
+        return base
+    count += 1
+    existing[base] = count
+    return f"{base}-{count}"
+
+
+def _language_path(language: str) -> Tuple[str, str]:
+    mapping = {
+        "php": ("php", "php"),
+        "html": ("html", "html"),
+        "javascript": ("js", "js"),
+        "css": ("css", "css"),
+    }
+    return mapping.get(language, (language, language or "txt"))
+
+
+def _php_repr(value) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_php_repr(item) for item in value) + "]"
+    if isinstance(value, dict):
+        parts = []
+        for key, item in value.items():
+            parts.append(f"'{key}' => {_php_repr(item)}")
+        return "[" + ", ".join(parts) + "]"
+    # strings
+    string = str(value)
+    string = string.replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{string}'"
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+
+
+def _normalize_php_code(code: str) -> str:
+    stripped = code.lstrip()
+    if stripped.startswith("<?php"):
+        stripped = stripped[5:]
+        if stripped.startswith("php"):
+            stripped = stripped[3:]
+    return stripped.lstrip()
+
+
+def _snippet_file_contents(snippet: Snippet, plan: PlannedSnippet) -> str:
+    if snippet.language == "php":
+        return "<?php\n" + _normalize_php_code(snippet.code).rstrip() + "\n"
+    return snippet.code.rstrip() + "\n"
+
+
+def _render_metadata(snippets: Iterable[PlannedSnippet], plugin_dir: Path) -> str:
+    entries: List[str] = []
+    for planned in snippets:
+        snippet = planned.snippet
+        plan = planned.plan
+        entry: Dict[str, object] = {
+            "id": snippet.identifier,
+            "title": snippet.title,
+            "status": plan.status,
+            "render_mode": plan.render_mode,
+            "priority": plan.priority,
+            "tags": snippet.tags,
+        }
+        if plan.reason:
+            entry["reason"] = plan.reason
+        if plan.hook:
+            entry["hook"] = plan.hook
+        if plan.hook_type:
+            entry["hook_type"] = plan.hook_type
+        if plan.placement:
+            entry["placement"] = plan.placement
+
+        snippet_dir, extension = _language_path(snippet.language)
+        entry["path"] = "/".join(
+            [
+                "snippets",
+                snippet_dir,
+                f"snippet-{snippet.identifier}.{extension}",
+            ]
+        )
+        if snippet.notes:
+            entry["notes"] = snippet.notes
+        entries.append(_php_repr(entry))
+
+    body = ",\n    ".join(entries)
+    return "<?php\n" \
+        + "$wpcode_generated_snippets = [\n    " \
+        + body \
+        + "\n];\n"
+
+
+def _render_loader_php() -> str:
+    return textwrap.dedent(
+        """<?php
+        if (!defined('ABSPATH')) {
+            exit;
+        }
+
+        require_once __DIR__ . '/snippet-data.php';
+
+        function wpcode_generated_normalize_handle($value)
+        {
+            $value = strtolower((string) $value);
+            $value = preg_replace('/[^a-z0-9_-]+/', '-', $value);
+            return trim($value, '-');
+        }
+
+        function wpcode_generated_get_snippet_file_path($snippet)
+        {
+            if (empty($snippet['path'])) {
+                return '';
+            }
+
+            $base = dirname(__DIR__);
+            $path = ltrim($snippet['path'], '/');
+
+            return $base . '/' . $path;
+        }
+
+        function wpcode_generated_execute_snippet($snippet)
+        {
+            $file = wpcode_generated_get_snippet_file_path($snippet);
+            if (empty($file) || !file_exists($file)) {
+                return '';
+            }
+
+            switch ($snippet['render_mode']) {
+                case 'php_include':
+                    include $file;
+                    return '';
+                case 'style_block':
+                    $handle = wpcode_generated_normalize_handle($snippet['id']);
+                    $content = file_get_contents($file);
+
+                    return '<style id="wpcode-snippet-' . esc_attr($handle) . '">' . $content . '</style>';
+                case 'script_block':
+                    $handle = wpcode_generated_normalize_handle($snippet['id']);
+                    $content = file_get_contents($file);
+
+                    return '<script id="wpcode-snippet-' . esc_attr($handle) . '">' . $content . '</script>';
+                default:
+                    return file_get_contents($file);
+            }
+        }
+
+        add_action('plugins_loaded', function () use (&$wpcode_generated_snippets) {
+            foreach ($wpcode_generated_snippets as $snippet) {
+                if ($snippet['status'] !== 'auto') {
+                    continue;
+                }
+
+                if ($snippet['hook_type'] === 'action') {
+                    add_action($snippet['hook'], function () use ($snippet) {
+                        $output = wpcode_generated_execute_snippet($snippet);
+
+                        if ($snippet['render_mode'] !== 'php_include' && $output !== '') {
+                            echo $output;
+                        }
+                    }, $snippet['priority']);
+                } elseif ($snippet['hook_type'] === 'filter') {
+                    add_filter($snippet['hook'], function ($content) use ($snippet) {
+                        $output = wpcode_generated_execute_snippet($snippet);
+
+                        if ($snippet['placement'] === 'before') {
+                            return $output . $content;
+                        }
+
+                        return $content . $output;
+                    }, $snippet['priority']);
+                } elseif ($snippet['hook_type'] === 'shortcode') {
+                    add_shortcode($snippet['hook'], function ($atts = [], $content = '') use ($snippet) {
+                        return wpcode_generated_execute_snippet($snippet);
+                    });
+                }
+            }
+        });
+        """
+    )
+
+def _render_admin_page() -> str:
+    return textwrap.dedent(
+        '<?php\n    if (!defined(\'ABSPATH\')) {\n        exit;\n    }\n\n    require_once __DIR__ . \'/snippet-data.php\';\n\n    function wpcode_generated_register_admin_assets()\n    {\n        wp_register_style(\n            \'wpcode-generated-admin\',\n            plugins_url(\'../assets/admin.css\', __FILE__),\n            [],\n            \'1.0.0\'\n        );\n    }\n\n    add_action(\'admin_init\', \'wpcode_generated_register_admin_assets\');\n\n    add_action(\'admin_enqueue_scripts\', function ($hook) {\n        if ($hook !== \'toplevel_page_wpcode-generated-snippets\') {\n            return;\n        }\n\n        wp_enqueue_style(\'wpcode-generated-admin\');\n    });\n\n    add_action(\'admin_menu\', function () {\n        add_menu_page(\n            \'Generated Snippets\',\n            \'Generated Snippets\',\n            \'manage_options\',\n            \'wpcode-generated-snippets\',\n            \'wpcode_generated_render_admin_page\',\n            \'dashicons-editor-code\',\n            81\n        );\n    });\n\n    function wpcode_generated_render_admin_page()\n    {\n        global $wpcode_generated_snippets;\n\n        echo \'<div class="wrap wpcode-generated">\';\n        echo \'<h1>Generated Snippets</h1>\';\n        if (empty($wpcode_generated_snippets)) {\n            echo \'<p>No snippets were imported.</p>\';\n            echo \'</div>\';\n            return;\n        }\n\n        echo \'<div class="wpcode-generated__grid">\';\n        foreach ($wpcode_generated_snippets as $snippet) {\n            $classes = \'wpcode-generated__card\';\n\n            if ($snippet[\'status\'] !== \'auto\') {\n                $classes .= \' wpcode-generated__card--manual\';\n            }\n\n            echo \'<section class="\' . esc_attr($classes) . \'">\';\n            echo \'<header>\';\n            echo \'<h2>\' . esc_html($snippet[\'title\']) . \'</h2>\';\n            if (!empty($snippet[\'tags\'])) {\n                echo \'<p class="wpcode-generated__tags">\';\n\n                foreach ($snippet[\'tags\'] as $tag) {\n                    echo \'<span class="wpcode-generated__tag">\' . esc_html($tag) . \'</span>\';\n                }\n\n                echo \'</p>\';\n            }\n\n            echo \'</header>\';\n            echo \'<dl class="wpcode-generated__meta">\';\n            echo \'<dt>Status</dt><dd>\' . esc_html($snippet[\'status\']) . \'</dd>\';\n\n            if (!empty($snippet[\'hook\'])) {\n                echo \'<dt>Hook</dt><dd>\' . esc_html($snippet[\'hook\']) . \'</dd>\';\n            }\n\n            if (!empty($snippet[\'hook_type\'])) {\n                echo \'<dt>Hook Type</dt><dd>\' . esc_html($snippet[\'hook_type\']) . \'</dd>\';\n            }\n\n            echo \'<dt>Priority</dt><dd>\' . intval($snippet[\'priority\']) . \'</dd>\';\n\n            if (!empty($snippet[\'placement\'])) {\n                echo \'<dt>Placement</dt><dd>\' . esc_html($snippet[\'placement\']) . \'</dd>\';\n            }\n\n            if (!empty($snippet[\'reason\'])) {\n                echo \'<dt>Notes</dt><dd>\' . esc_html($snippet[\'reason\']) . \'</dd>\';\n            } elseif (!empty($snippet[\'notes\'])) {\n                echo \'<dt>Notes</dt><dd>\' . esc_html($snippet[\'notes\']) . \'</dd>\';\n            }\n\n            echo \'</dl>\';\n            $file_path = wpcode_generated_get_snippet_file_path($snippet);\n\n            if ($file_path && file_exists($file_path)) {\n                $code = esc_html(file_get_contents($file_path));\n                echo \'<pre class="wpcode-generated__code"><code>\' . $code . \'</code></pre>\';\n            }\n\n            echo \'</section>\';\n        }\n\n        echo \'</div>\';\n        echo \'</div>\';\n    }\n'
+    )
+
+def _render_admin_css() -> str:
+    return ".wpcode-generated__grid {\n" \
+        "    display: grid;\n" \
+        "    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));\n" \
+        "    gap: 1.5rem;\n" \
+        "}\n" \
+        ".wpcode-generated__card {\n" \
+        "    background: #fff;\n" \
+        "    border: 1px solid #ccd0d4;\n" \
+        "    border-radius: 6px;\n" \
+        "    padding: 1rem;\n" \
+        "    box-shadow: 0 1px 2px rgba(30, 41, 59, 0.06);\n" \
+        "}\n" \
+        ".wpcode-generated__card--manual {\n" \
+        "    border-color: #d63638;\n" \
+        "    box-shadow: 0 0 0 2px rgba(214, 54, 56, 0.15);\n" \
+        "}\n" \
+        ".wpcode-generated__meta {\n" \
+        "    display: grid;\n" \
+        "    grid-template-columns: auto 1fr;\n" \
+        "    gap: 0.25rem 1rem;\n" \
+        "    font-size: 0.875rem;\n" \
+        "    margin-bottom: 1rem;\n" \
+        "}\n" \
+        ".wpcode-generated__meta dt {\n" \
+        "    font-weight: 600;\n" \
+        "    color: #1d2327;\n" \
+        "}\n" \
+        ".wpcode-generated__meta dd {\n" \
+        "    margin: 0;\n" \
+        "    color: #50575e;\n" \
+        "}\n" \
+        ".wpcode-generated__code {\n" \
+        "    background: #f6f7f7;\n" \
+        "    border-radius: 4px;\n" \
+        "    padding: 1rem;\n" \
+        "    overflow-x: auto;\n" \
+        "}\n" \
+        ".wpcode-generated__tag {\n" \
+        "    display: inline-block;\n" \
+        "    background: #f0f6ff;\n" \
+        "    color: #1d4ed8;\n" \
+        "    padding: 0.2rem 0.5rem;\n" \
+        "    border-radius: 999px;\n" \
+        "    font-size: 0.75rem;\n" \
+        "    margin-right: 0.25rem;\n" \
+        "}\n"
+
+
+def build_plugin(
+    export_path: str | Path,
+    output_directory: str | Path,
+    plugin_slug: str = "wpcode-generated-snippets",
+    plugin_name: str = "WPCode Generated Snippets",
+    *,
+    verbose: bool = False,
+    log=None,
+) -> Path:
+    export_path = Path(export_path)
+    output_directory = Path(output_directory)
+    logger = _resolve_logger(verbose, log)
+
+    if logger:
+        logger(
+            f"Building plugin '{plugin_slug}' from {export_path} into {output_directory}"
+        )
+
+    planned_snippets = [
+        plan_snippet(snippet)
+        for snippet in _load_snippets(export_path, verbose=verbose, log=logger)
+    ]
+
+    plugin_dir = output_directory / plugin_slug
+    if plugin_dir.exists():
+        shutil.rmtree(plugin_dir)
+    plugin_dir.mkdir(parents=True)
+
+    slug_registry: Dict[str, int] = {}
+    for planned in planned_snippets:
+        snippet = planned.snippet
+        base_slug = _sanitize_slug(snippet.identifier)
+        slug = _unique_slug(base_slug, slug_registry)
+        snippet.identifier = slug
+
+        snippet_dir_name, extension = _language_path(snippet.language)
+        file_path = plugin_dir / "snippets" / snippet_dir_name / f"snippet-{slug}.{extension}"
+        _write_file(file_path, _snippet_file_contents(snippet, planned))
+
+        if logger:
+            relative_path = file_path.relative_to(plugin_dir)
+            logger(f"- Wrote {relative_path}")
+
+    metadata = _render_metadata(planned_snippets, plugin_dir)
+    _write_file(plugin_dir / "includes" / "snippet-data.php", metadata)
+    _write_file(plugin_dir / "includes" / "loader.php", _render_loader_php())
+    _write_file(plugin_dir / "includes" / "admin-page.php", _render_admin_page())
+    _write_file(plugin_dir / "assets" / "admin.css", _render_admin_css())
+
+    if logger:
+        logger(f"Plugin files written to {plugin_dir}")
+
+    main_php = "<?php\n" \
+        + "/**\n" \
+        + f" * Plugin Name: {plugin_name}\n" \
+        + " * Description: Generated from a WPCode export.\n" \
+        + " * Version: 1.0.0\n" \
+        + " * Author: WPCode Conversion Tool\n" \
+        + " */\n\n" \
+        + "if (!defined('ABSPATH')) {\n" \
+        + "    exit;\n" \
+        + "}\n\n" \
+        + "require_once __DIR__ . '/includes/loader.php';\n" \
+        + "require_once __DIR__ . '/includes/admin-page.php';\n"
+
+    _write_file(plugin_dir / f"{plugin_slug}.php", main_php)
+
+    return plugin_dir
+
+
+def _load_snippets(path: Path, **kwargs) -> List[Snippet]:
+    from .parser import load_snippets
+
+    return load_snippets(path, **kwargs)

--- a/src/wpcode_tool/cli.py
+++ b/src/wpcode_tool/cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .builder import build_plugin
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Convert a WPCode export into a standalone WordPress plugin.",
+    )
+    parser.add_argument("export", type=Path, help="Path to the WPCode export JSON file")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("build"),
+        help="Directory where the plugin should be created (default: ./build)",
+    )
+    parser.add_argument(
+        "--slug",
+        default="wpcode-generated-snippets",
+        help="Plugin slug (default: wpcode-generated-snippets)",
+    )
+    parser.add_argument(
+        "--name",
+        default="WPCode Generated Snippets",
+        help="Plugin name (default: WPCode Generated Snippets)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging during generation",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    plugin_path = build_plugin(
+        export_path=args.export,
+        output_directory=args.output,
+        plugin_slug=args.slug,
+        plugin_name=args.name,
+        verbose=args.verbose,
+    )
+    print(f"Plugin created at {plugin_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/wpcode_tool/mapper.py
+++ b/src/wpcode_tool/mapper.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict
+
+from .models import HookPlan, PlannedSnippet, Snippet
+
+
+@dataclass(frozen=True)
+class HookMapping:
+    hook_type: str
+    hook: str
+    placement: str | None = None
+
+
+LOCATION_MAP: Dict[str, HookMapping] = {
+    "everywhere": HookMapping("action", "init"),
+    "global": HookMapping("action", "init"),
+    "frontend": HookMapping("action", "wp"),
+    "frontend only": HookMapping("action", "wp"),
+    "admin": HookMapping("action", "admin_init"),
+    "backend": HookMapping("action", "admin_init"),
+    "site-wide header": HookMapping("action", "wp_head"),
+    "site wide header": HookMapping("action", "wp_head"),
+    "site-wide footer": HookMapping("action", "wp_footer"),
+    "site wide footer": HookMapping("action", "wp_footer"),
+    "footer": HookMapping("action", "wp_footer"),
+    "header": HookMapping("action", "wp_head"),
+    "before content": HookMapping("filter", "the_content", placement="before"),
+    "after content": HookMapping("filter", "the_content", placement="after"),
+    "content": HookMapping("filter", "the_content"),
+}
+
+DEFAULT_HOOKS: Dict[str, HookMapping] = {
+    "php": HookMapping("action", "init"),
+    "html": HookMapping("action", "wp_footer"),
+    "javascript": HookMapping("action", "wp_footer"),
+    "css": HookMapping("action", "wp_head"),
+}
+
+
+RENDER_MODE_BY_LANGUAGE: Dict[str, str] = {
+    "php": "php_include",
+    "html": "html",
+    "javascript": "script_block",
+    "css": "style_block",
+}
+
+
+def _normalize_location(location: str | None) -> str | None:
+    if not location:
+        return None
+    return re.sub(r"\s+", " ", location.strip().lower())
+
+
+def _plan_known_location(snippet: Snippet, normalized_location: str) -> HookPlan | None:
+    mapping = LOCATION_MAP.get(normalized_location)
+    if mapping:
+        return HookPlan(
+            status="auto",
+            render_mode=RENDER_MODE_BY_LANGUAGE.get(snippet.language, "html"),
+            hook_type=mapping.hook_type,
+            hook=mapping.hook,
+            placement=mapping.placement,
+            priority=snippet.priority,
+        )
+    return None
+
+
+def plan_snippet(snippet: Snippet) -> PlannedSnippet:
+    normalized_location = _normalize_location(snippet.location)
+
+    render_mode = RENDER_MODE_BY_LANGUAGE.get(snippet.language, "html")
+
+    if normalized_location:
+        plan = _plan_known_location(snippet, normalized_location)
+        if plan:
+            return PlannedSnippet(snippet=snippet, plan=plan)
+        if normalized_location in {"manual", "shortcode", "php function"}:
+            return PlannedSnippet(
+                snippet=snippet,
+                plan=HookPlan(
+                    status="manual",
+                    render_mode=render_mode,
+                    reason=f"Manual placement required for location '{snippet.location}'.",
+                ),
+            )
+
+    default_mapping = DEFAULT_HOOKS.get(snippet.language)
+    if default_mapping:
+        plan = HookPlan(
+            status="auto",
+            render_mode=render_mode,
+            hook_type=default_mapping.hook_type,
+            hook=default_mapping.hook,
+            priority=snippet.priority,
+        )
+        return PlannedSnippet(snippet=snippet, plan=plan)
+
+    return PlannedSnippet(
+        snippet=snippet,
+        plan=HookPlan(
+            status="manual",
+            render_mode=render_mode,
+            reason="Unable to determine placement for snippet.",
+        ),
+    )

--- a/src/wpcode_tool/models.py
+++ b/src/wpcode_tool/models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Snippet:
+    """Normalized representation of a WPCode snippet."""
+
+    identifier: str
+    title: str
+    code: str
+    language: str
+    active: bool
+    location: Optional[str]
+    priority: int
+    tags: List[str]
+    notes: Optional[str] = None
+
+
+@dataclass
+class HookPlan:
+    """Information about how a snippet should be executed inside a plugin."""
+
+    status: str  # "auto" or "manual"
+    render_mode: str  # php_include, html, style_block, script_block
+    hook_type: Optional[str] = None  # action, filter, shortcode
+    hook: Optional[str] = None
+    priority: int = 10
+    placement: Optional[str] = None  # before/after for filters
+    reason: Optional[str] = None
+
+
+@dataclass
+class PlannedSnippet:
+    snippet: Snippet
+    plan: HookPlan
+
+    def is_manual(self) -> bool:
+        return self.plan.status != "auto"

--- a/src/wpcode_tool/parser.py
+++ b/src/wpcode_tool/parser.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Iterable, List, Sequence
+
+from .models import Snippet
+
+
+def _ensure_list(value: object) -> List[object]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _normalize_language(value: str | None) -> str:
+    if not value:
+        return "php"
+    value = value.strip().lower()
+    aliases = {
+        "javascript": "javascript",
+        "js": "javascript",
+        "css": "css",
+        "html": "html",
+        "php": "php",
+        "text": "html",
+    }
+    return aliases.get(value, value)
+
+
+def _extract_location(entry: dict) -> str | None:
+    auto_insert = entry.get("auto_insert")
+    if isinstance(auto_insert, dict):
+        location = auto_insert.get("location") or auto_insert.get("locations")
+        if isinstance(location, list):
+            return str(location[0]).strip() if location else None
+        if location:
+            return str(location).strip()
+        # Some exports store location directly on auto_insert
+        if "type" in auto_insert:
+            return str(auto_insert["type"]).strip()
+    if "location" in entry:
+        return str(entry["location"]).strip()
+    if "insert_location" in entry:
+        return str(entry["insert_location"]).strip()
+    return None
+
+
+def _extract_priority(entry: dict) -> int:
+    auto_insert = entry.get("auto_insert")
+    if isinstance(auto_insert, dict):
+        priority = auto_insert.get("priority") or auto_insert.get("order")
+        if priority is not None:
+            try:
+                return int(priority)
+            except (TypeError, ValueError):
+                pass
+    priority = entry.get("priority")
+    if priority is not None:
+        try:
+            return int(priority)
+        except (TypeError, ValueError):
+            pass
+    return 10
+
+
+def _extract_tags(entry: dict) -> List[str]:
+    tags = _ensure_list(entry.get("tags"))
+    return [str(tag).strip() for tag in tags if str(tag).strip()]
+
+
+def _extract_identifier(entry: dict) -> str:
+    for key in ("id", "ID", "snippet_id"):
+        if key in entry and entry[key] not in (None, ""):
+            return str(entry[key])
+    if "title" in entry and entry["title"]:
+        return str(entry["title"]).strip().lower().replace(" ", "-")
+    if "name" in entry and entry["name"]:
+        return str(entry["name"]).strip().lower().replace(" ", "-")
+    raise ValueError("Snippet entry is missing an identifier")
+
+
+def _extract_title(entry: dict) -> str:
+    for key in ("title", "name", "label"):
+        if key in entry and entry[key]:
+            return str(entry[key]).strip()
+    return f"Snippet {entry.get('id', '')}".strip()
+
+
+def _extract_code(entry: dict) -> str:
+    for key in ("code", "snippet", "content"):
+        if key in entry and entry[key] not in (None, ""):
+            return str(entry[key])
+    return ""
+
+
+def _is_active(entry: dict) -> bool:
+    for key in ("active", "is_active", "enabled", "status"):
+        if key in entry:
+            value = entry[key]
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float)):
+                return bool(value)
+            if isinstance(value, str):
+                return value.strip().lower() in {"true", "1", "active", "enabled", "on"}
+    auto_insert = entry.get("auto_insert")
+    if isinstance(auto_insert, dict):
+        return False
+    if isinstance(auto_insert, bool):
+        return auto_insert
+    if isinstance(auto_insert, (int, float)):
+        return bool(auto_insert)
+    if isinstance(auto_insert, str):
+        normalized = auto_insert.strip().lower()
+        if normalized in {"true", "1", "yes", "on", "active", "enabled"}:
+            return True
+        if normalized in {"false", "0", "no", "off", "inactive", "disabled"}:
+            return False
+        return bool(normalized)
+    return False
+
+
+def _iter_snippet_entries(data: object) -> Iterable[dict]:
+    if isinstance(data, dict):
+        if "snippets" in data:
+            snippets = data["snippets"]
+            if isinstance(snippets, dict):
+                for entry in snippets.values():
+                    if isinstance(entry, dict):
+                        yield entry
+            elif isinstance(snippets, Sequence):
+                for entry in snippets:
+                    if isinstance(entry, dict):
+                        yield entry
+        else:
+            # Maybe the dict is already a snippet definition
+            if all(key in data for key in ("code", "title")):
+                yield data
+    elif isinstance(data, Sequence):
+        for entry in data:
+            if isinstance(entry, dict):
+                yield entry
+
+
+def _entry_label(entry: dict) -> str:
+    for key in ("id", "title", "name", "label"):
+        if key in entry and entry[key]:
+            return str(entry[key])
+    return "<unknown>"
+
+
+def load_snippets(
+    path: str | Path,
+    *,
+    verbose: bool = False,
+    log: Callable[[str], None] | None = None,
+) -> List[Snippet]:
+    """Load and normalize active snippets from a WPCode export."""
+
+    path = Path(path)
+    with path.open("r", encoding="utf-8") as handle:
+        raw = json.load(handle)
+
+    logger: Callable[[str], None] | None = log if verbose else None
+    if verbose and logger is None:
+        logger = print
+
+    entries = list(_iter_snippet_entries(raw))
+    if logger:
+        logger(f"Found {len(entries)} snippet entr{'y' if len(entries) == 1 else 'ies'} in {path}")
+
+    snippets: List[Snippet] = []
+    for entry in entries:
+        if not _is_active(entry):
+            if logger:
+                logger(f"- Skipping inactive snippet {_entry_label(entry)!r}")
+            continue
+
+        identifier = _extract_identifier(entry)
+        snippet = Snippet(
+            identifier=identifier,
+            title=_extract_title(entry),
+            code=_extract_code(entry),
+            language=_normalize_language(entry.get("code_type") or entry.get("type")),
+            active=True,
+            location=_extract_location(entry),
+            priority=_extract_priority(entry),
+            tags=_extract_tags(entry),
+            notes=str(entry.get("notes")) if entry.get("notes") else None,
+        )
+        snippets.append(snippet)
+
+        if logger:
+            logger(f"- Loaded snippet {identifier!r} ({snippet.language})")
+
+    if logger:
+        logger(f"Collected {len(snippets)} active snippet{'s' if len(snippets) != 1 else ''}")
+
+    return snippets

--- a/tests/fixtures/wpcode_export.json
+++ b/tests/fixtures/wpcode_export.json
@@ -1,0 +1,50 @@
+{
+  "generated_at": "2024-01-10 12:00:00",
+  "plugin": "wpcode",
+  "snippets": [
+    {
+      "id": 101,
+      "title": "Add Custom Body Class",
+      "code": "add_filter('body_class', function ($classes) {\\n    $classes[] = 'custom-body';\\n    return $classes;\\n});",
+      "code_type": "php",
+      "active": true,
+      "auto_insert": {
+        "location": "everywhere",
+        "priority": 12
+      },
+      "tags": ["theme", "layout"],
+      "notes": "Adds a CSS class to the body tag"
+    },
+    {
+      "id": 102,
+      "title": "Marketing Banner",
+      "code": "<div class=\"marketing-banner\">Don't miss out!</div>",
+      "code_type": "html",
+      "active": true,
+      "auto_insert": {
+        "location": "site-wide footer"
+      },
+      "tags": ["marketing"]
+    },
+    {
+      "id": 103,
+      "title": "Admin Column Tweak",
+      "code": "add_filter('manage_posts_columns', function ($columns) {\\n    $columns['custom'] = 'Custom';\\n    return $columns;\\n});",
+      "code_type": "php",
+      "active": false,
+      "auto_insert": {
+        "location": "admin"
+      }
+    },
+    {
+      "id": 104,
+      "title": "Needs Manual Placement",
+      "code": "echo '<div>Manual placement required</div>';",
+      "code_type": "php",
+      "active": true,
+      "auto_insert": {
+        "location": "manual"
+      }
+    }
+  ]
+}

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from wpcode_tool.builder import build_plugin
+
+FIXTURE = Path(__file__).parent / "fixtures" / "wpcode_export.json"
+
+
+def test_build_plugin_creates_wordpress_plugin(tmp_path: Path):
+    plugin_path = build_plugin(FIXTURE, tmp_path, plugin_slug="generated-snippets")
+
+    main_file = plugin_path / "generated-snippets.php"
+    metadata_file = plugin_path / "includes" / "snippet-data.php"
+    loader_file = plugin_path / "includes" / "loader.php"
+    admin_file = plugin_path / "includes" / "admin-page.php"
+    php_snippet = plugin_path / "snippets" / "php" / "snippet-101.php"
+    html_snippet = plugin_path / "snippets" / "html" / "snippet-102.html"
+
+    assert main_file.exists()
+    assert metadata_file.exists()
+    assert loader_file.exists()
+    assert admin_file.exists()
+    assert php_snippet.exists()
+    assert html_snippet.exists()
+
+    metadata = metadata_file.read_text(encoding="utf-8")
+    assert "'title' => 'Add Custom Body Class'" in metadata
+    assert "'hook' => 'init'" in metadata
+    assert "'status' => 'manual'" in metadata
+    assert "'path' => 'snippets/php/snippet-101.php'" in metadata
+
+    php_code = php_snippet.read_text(encoding="utf-8")
+    assert "add_filter('body_class'" in php_code
+
+    admin_page = admin_file.read_text(encoding="utf-8")
+    assert "Generated Snippets" in admin_page
+    assert "wpcode-generated__card--manual" in admin_page
+
+
+def test_subsequent_runs_overwrite_existing_output(tmp_path: Path):
+    build_plugin(FIXTURE, tmp_path, plugin_slug="generated-snippets")
+    first_files = sorted(p.relative_to(tmp_path) for p in tmp_path.rglob("*") if p.is_file())
+
+    build_plugin(FIXTURE, tmp_path, plugin_slug="generated-snippets")
+    second_files = sorted(p.relative_to(tmp_path) for p in tmp_path.rglob("*") if p.is_file())
+
+    assert first_files == second_files
+
+
+def test_build_plugin_verbose_emits_messages(tmp_path: Path):
+    messages: list[str] = []
+
+    build_plugin(
+        FIXTURE,
+        tmp_path,
+        plugin_slug="generated-snippets",
+        verbose=True,
+        log=messages.append,
+    )
+
+    assert any("Building plugin" in message for message in messages)
+    assert any("Wrote" in message for message in messages)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wpcode_tool.parser import load_snippets
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "wpcode_export.json"
+
+
+def test_load_snippets_filters_inactive_entries():
+    snippets = load_snippets(FIXTURE)
+    identifiers = {snippet.identifier for snippet in snippets}
+
+    assert identifiers == {"101", "102", "104"}
+
+
+def test_load_snippets_preserves_metadata():
+    snippets = load_snippets(FIXTURE)
+    snippet = next(s for s in snippets if s.identifier == "101")
+
+    assert snippet.title == "Add Custom Body Class"
+    assert snippet.language == "php"
+    assert snippet.priority == 12
+    assert snippet.location == "everywhere"
+    assert snippet.tags == ["theme", "layout"]
+    assert snippet.notes == "Adds a CSS class to the body tag"
+
+
+def test_load_snippets_honors_legacy_auto_insert(tmp_path):
+    export = [
+        {
+            "id": 1,
+            "title": "Active legacy snippet",
+            "code": "<?php echo 'active'; ?>",
+            "code_type": "php",
+            "auto_insert": 1,
+        },
+        {
+            "id": 2,
+            "title": "Inactive legacy snippet",
+            "code": "<?php echo 'inactive'; ?>",
+            "code_type": "php",
+            "auto_insert": 0,
+        },
+    ]
+    path = tmp_path / "legacy.json"
+    path.write_text(json.dumps(export), encoding="utf-8")
+
+    snippets = load_snippets(path)
+
+    assert [snippet.identifier for snippet in snippets] == ["1"]
+
+
+def test_load_snippets_reports_languages_and_counts(tmp_path):
+    export = {
+        "snippets": [
+            {
+                "id": "php",
+                "title": "PHP Snippet",
+                "code": "<?php echo 'php'; ?>",
+                "code_type": "php",
+                "active": True,
+            },
+            {
+                "id": "css",
+                "title": "CSS Snippet",
+                "code": ".example { color: red; }",
+                "code_type": "css",
+                "active": True,
+            },
+            {
+                "id": "js",
+                "title": "JS Snippet",
+                "code": "console.log('js');",
+                "code_type": "js",
+                "active": True,
+            },
+        ]
+    }
+    path = tmp_path / "languages.json"
+
+    path.write_text(json.dumps(export), encoding="utf-8")
+
+    snippets = load_snippets(path)
+
+    languages = sorted(snippet.language for snippet in snippets)
+
+    assert len(snippets) == 3
+    assert languages == ["css", "javascript", "php"]
+
+
+def test_load_snippets_verbose_logging(tmp_path, capsys):
+    export = [
+        {
+            "id": "active",
+            "title": "Active snippet",
+            "code": "<?php echo 'active'; ?>",
+            "code_type": "php",
+            "auto_insert": 1,
+        },
+        {
+            "id": "inactive",
+            "title": "Inactive snippet",
+            "code": "<?php echo 'inactive'; ?>",
+            "code_type": "php",
+            "auto_insert": 0,
+        },
+    ]
+    path = tmp_path / "verbose.json"
+    path.write_text(json.dumps(export), encoding="utf-8")
+
+    snippets = load_snippets(path, verbose=True)
+
+    out = capsys.readouterr().out
+
+    assert len(snippets) == 1
+    assert "Found 2 snippet entries" in out
+    assert "Skipping inactive snippet 'inactive'" in out
+    assert "Loaded snippet 'active'" in out


### PR DESCRIPTION
## Summary
- add optional verbose logging to snippet loading and plugin generation, including a CLI flag
- log skipped entries and written files to help diagnose empty builds and document the option in the README
- cover the new behavior with parser and builder tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68cba679f7f8832f9d020f649cbcd514